### PR TITLE
Added config option to lie about holes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
         exclude ( group = "org.jetbrains", module = "annotations" )
         exclude ( group = "org.intellij.lang", module = "annotations" )
     }
-    implementation ("com.github.TechnicJelle:BMUtils:v3.0") {
+    implementation ("com.github.TechnicJelle:BMUtils:v4.2") {
         exclude ( group = "org.jetbrains", module = "annotations" )
         exclude ( group = "org.intellij.lang", module = "annotations" )
     }

--- a/src/main/java/codes/antti/bluemaptowny/BlueMapTowny.java
+++ b/src/main/java/codes/antti/bluemaptowny/BlueMapTowny.java
@@ -279,15 +279,16 @@ public final class BlueMapTowny extends JavaPlugin {
                     String siegeDetails = fillPlaceholders(this.config.getString("popup-siege"), town);
                     int seq = 0;
                     for (Cheese cheese : cheeses) {
-                        ShapeMarker chunkMarker = new ShapeMarker.Builder()
+                        ShapeMarker.Builder chunkMarkerBuilder = new ShapeMarker.Builder()
                                 .label(townName)
                                 .detail(townDetails)
                                 .lineColor(getLineColor(town))
                                 .lineWidth(this.config.getInt("style.border-width"))
                                 .fillColor(getFillColor(town))
                                 .depthTestEnabled(false)
-                                .shape(cheese.getShape(), (float) layerY)
-                                .holes(cheese.getHoles().toArray(Shape[]::new))
+                                .shape(cheese.getShape(), (float) layerY);
+                        if (this.config.getBoolean("lie-about-holes", false) == false) chunkMarkerBuilder.holes(cheese.getHoles().toArray(Shape[]::new));
+                        ShapeMarker chunkMarker = chunkMarkerBuilder
                                 .centerPosition()
                                 .build();
                         markers.put("towny." + townName + ".area." + seq, chunkMarker);

--- a/src/main/java/codes/antti/bluemaptowny/BlueMapTowny.java
+++ b/src/main/java/codes/antti/bluemaptowny/BlueMapTowny.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import com.flowpowered.math.vector.Vector2d;
 import com.technicjelle.BMUtils.Cheese;
 import de.bluecolored.bluemap.api.markers.*;
 import org.apache.commons.lang.WordUtils;
@@ -269,7 +270,9 @@ public final class BlueMapTowny extends JavaPlugin {
                 if (townyworld == null) continue;
                 TownyAPI.getInstance().getTowns().forEach((town) -> {
                     Vector2i[] chunks = town.getTownBlocks().stream().filter((tb) -> tb.getWorld().equals(townyworld)).map((tb) -> new Vector2i(tb.getX(), tb.getZ())).toArray(Vector2i[]::new);
-                    Collection<Cheese> cheeses = Cheese.createPlatterFromChunks(chunks);
+                    int townSize = TownySettings.getTownBlockSize();
+                    Vector2d cellSize = new Vector2d(townSize, townSize);
+                    Collection<Cheese> cheeses = Cheese.createPlatterFromCells(cellSize, chunks);
                     double layerY = this.config.getDouble("style.y-level");
                     String townName = town.getName();
                     String townDetails = fillPlaceholders(this.config.getString("popup"), town);

--- a/src/main/java/codes/antti/bluemaptowny/BlueMapTowny.java
+++ b/src/main/java/codes/antti/bluemaptowny/BlueMapTowny.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import com.technicjelle.Cheese;
+import com.technicjelle.BMUtils.Cheese;
 import de.bluecolored.bluemap.api.markers.*;
 import org.apache.commons.lang.WordUtils;
 import org.bukkit.Bukkit;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,6 +11,9 @@ dynamic-town-colors: true
 popup: '<span style="font-size: 120%">%name% (%nation%)</span><br><span>Mayor <strong>%mayor%</strong></span><br><span>Residents <strong>%residents%</strong></span><br><span>Bank <strong>%bank%</strong></span>'
 # HTML for War popup(SiegeWar Only), placeholders documented in README
 popup-siege: '<span style="font-size: 120%"><strong>Siege: %attacker% vs %defender%</strong></span><br><hr><span>Town <strong>%name%</strong></span><br><span>Type <strong>%siege_type%</strong></span><br><span>War Chest <strong>%war_chest%</strong></span><br><span>Siege Progress <strong>%sessions_completed%/%sessions_total%</strong></span><br><span>Siege Status <strong>%siege_status%</strong></span><br><span>Siege Balance <strong>%siege_balance%</strong></span><br><span>Banner Control <strong>%banner_control%</strong></span><br><span>Battle Points <strong>%battle_points_attacker% / %battle_points_defender%</strong></span><br><span>Battle Time Left <strong>%battle_time_left%</strong></span>'
+# If you want claims with holes in them to show up as fully claimed if only the perimeter is claimed.
+# This means that the map will LIE about the actual claim status of the area!!!
+lie-about-holes: false
 style:
   # Y-level to put markers at
   y-level: 62


### PR DESCRIPTION
(Merge #12 first)

People coming from Dynmap are used to the Towny integration lying to them, which the BlueMap integration does not do.

Apparently, the Dynmap integration shows claims like these without holes; as if they were fully claimed.
Even though the inside chunks are _not_ actually claimed.
![image](https://github.com/user-attachments/assets/c58219bf-19f0-4092-b476-0be9c06e3c44)

I do not recommend merging this PR, because it incentivises people to ""fix"" the problem in the wrong way.
They should just claim the chunks in the middle, instead of showing lies and deceit.
It could be used for exploits and griefing.
If people think their towns are claimed, while in reality only the perimeter is claimed, this gives them a false sense of security. It allows malevolent people to grief their towns.

Relevant xkcd: https://xkcd.com/1172/