### PR TITLE
Improving the names shown on map

### DIFF
--- a/src/main/java/codes/antti/bluemaptowny/BlueMapTowny.java
+++ b/src/main/java/codes/antti/bluemaptowny/BlueMapTowny.java
@@ -186,7 +186,7 @@ public final class BlueMapTowny extends JavaPlugin {
             t = t.replace("%bank%", TownyEconomyHandler.getFormattedBalance(town.getAccount().getCachedBalance()));
         }
 
-        String nation = town.hasNation() ? Objects.requireNonNull(town.getNationOrNull()).getName() : "";
+        String nation = town.hasNation() ? Objects.requireNonNull(town.getNationOrNull()).getName().replace("_", " ") : "";
         t = t.replace("%nation%", nation);
         t = t.replace("%nationstatus%", town.hasNation() ? (town.isCapital() ? "Capital of " + nation : "Member of " + nation) : "");
 

--- a/src/main/java/codes/antti/bluemaptowny/BlueMapTowny.java
+++ b/src/main/java/codes/antti/bluemaptowny/BlueMapTowny.java
@@ -144,7 +144,7 @@ public final class BlueMapTowny extends JavaPlugin {
     private String fillPlaceholders(String template, Town town) {
         String t = template;
 
-        t = t.replace("%name%", town.getName());
+        t = t.replace("%name%", town.getName().replace("_", " "));
 
         t = t.replace("%mayor%", town.hasMayor() ? town.getMayor().getName() : "");
 


### PR DESCRIPTION
This pull request improves the readability of names displayed on the map by replacing underscores (_) in names with actual spaces. This adjustment ensures that names are more user-friendly and better aligned with standard formatting expectations.

Changes:

Replaced underscores in town names with spaces for a cleaner map display.
This change does not impact the underlying functionality but enhances the visual presentation for users.
*Edit:* Replaced underscores in nation names with spaces for a cleaner map display.